### PR TITLE
Add optional support for `darling` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Emitter::new()` and `Emitter::into_error()` to enable using the Emitter manually.
 - Implemented `Extend` for `Emitter` and `Error`.
 - Added `emit!` macro for adding errors to `Emitter`.
+- Added support for converting `darling::Error` to `manyhow::Error` (available via `darling` feature).
 
 ### Changed
 - **Breaking Change** replaced `Emitter::fail_if_dirty` with `Emitter::into_result`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ proc-macro2 = "1.0.60"
 quote = "1"
 syn1 = { package = "syn", version = "1", default-features = false, optional = true, features = ["printing"] }
 syn2 = { package = "syn", version = "2", default-features = false, optional = true, features = ["printing"] }
+darling_core = { version = "0.20.1", optional = true }
 
 [features]
 default = ["syn"]
 syn = ["syn2"]
+darling = ["darling_core"]
 
 [dev-dependencies]
 proc-macro-utils = "0.8.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ use quote::{quote_spanned, ToTokens};
 use syn1::Error as Syn1Error;
 #[cfg(feature = "syn2")]
 use syn2::Error as Syn2Error;
+#[cfg(feature = "darling")]
+use darling_core::Error as DarlingError;
 
 #[cfg(doc)]
 use crate::MacroHandler;
@@ -36,6 +38,12 @@ impl From<Syn1Error> for Error {
 #[cfg(feature = "syn2")]
 impl From<Syn2Error> for Error {
     fn from(error: Syn2Error) -> Self {
+        Self::from(error)
+    }
+}
+#[cfg(feature = "darling")]
+impl From<DarlingError> for Error {
+    fn from(error: DarlingError) -> Self {
         Self::from(error)
     }
 }
@@ -325,6 +333,12 @@ impl ToTokensError for Syn1Error {
 impl ToTokensError for Syn2Error {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.to_compile_error().to_tokens(tokens);
+    }
+}
+#[cfg(feature = "darling")]
+impl ToTokensError for DarlingError {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.clone().write_errors().to_tokens(tokens);
     }
 }
 impl ToTokensError for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@
 //!
 //! - `syn`/`syn2` **default** Enables errors for [`syn` 2.x](https://docs.rs/syn/latest/syn/).
 //! - `syn1` Enables errors for [`syn` 1.x](https://docs.rs/syn/1.0.109/syn/index.html).
+//! - `darling` Enables erros for [`darling`](https://docs.rs/darling/latest/index.html).
 
 use std::convert::Infallible;
 
@@ -442,7 +443,7 @@ pub fn function<
 pub trait MacroHandler<Input, Output, Function, Error = Infallible> {
     #[allow(clippy::missing_errors_doc, missing_docs)]
     fn call(self, input: Input, dummy: &mut Output, emitter: &mut Emitter)
-    -> Result<Output, Error>;
+        -> Result<Output, Error>;
 }
 
 macro_rules! impl_attribute_macro {


### PR DESCRIPTION
This allows using darling with manyhow without extra boilerplate:

```rust
#[manyhow]
#[proc_macro_attribute]
fn hello_macro(args: TokenStream, item: TokenStream) -> manyhow::Result<TokenStream> {
    let args = NestedMeta::parse_meta_list(args)?;
    let VersionArgs {
        n: version_number,
        versioned: versioned_struct_name,
    } = VersionArgs::from_list(&args)?;

   ...
}

```