### PR TITLE
Implement support for `impl Parse` and `impl ToTokens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- support `impl Parse` inputs and `impl ToTokens` outputs.
+- added macro alternatives to the `function()`, `derive()` and `attribute()` functions to support `impl Parse/ToTokens`.
+
 ## [0.8.1] - 2023-09-17
 ### Fixed
 - `ensure!(let...)` had compile error in its expansion.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ darling = ["darling_core"]
 [dev-dependencies]
 proc-macro-utils = "0.8.0"
 proc-macro2 = { version = "1", features = ["span-locations"] }
+syn2 = {package = "syn", version = "2", features = ["full"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ documentation = "https://docs.rs/manyhow"
 members = [ "macros", ".", "examples/macro", "examples/no_macro" ]
 
 [dependencies]
-macros = { package = "manyhow-macros", path = "macros", version = "0.8.1" }
+macros = { package = "manyhow-macros", path = "macros", version = "0.8.1", optional = true}
 proc-macro2 = "1.0.60"
 quote = "1"
 syn1 = { package = "syn", version = "1", default-features = false, optional = true, features = ["printing"] }
-syn2 = { package = "syn", version = "2", default-features = false, optional = true, features = ["printing"] }
+syn2 = { package = "syn", version = "2", default-features = false, optional = true, features = ["printing", "parsing"] }
 darling_core = { version = "0.20.1", optional = true }
 
 [features]
-default = ["syn"]
+default = ["syn", "macros"]
 syn = ["syn2"]
 darling = ["darling_core"]
 

--- a/examples/macro/Cargo.toml
+++ b/examples/macro/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-manyhow = {path = "../..", default-features = false}
+manyhow = {path = "../..", default-features = false, features = ["macros", "syn"]}
 proc-macro2 = "1"
 quote = "1"
-syn = "2"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.80"

--- a/examples/macro/src/lib.rs
+++ b/examples/macro/src/lib.rs
@@ -1,4 +1,4 @@
-use manyhow::{manyhow, Emitter, ErrorMessage, Result, SilentError};
+use manyhow::{bail, manyhow, Emitter, ErrorMessage, Result, SilentError};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
@@ -139,3 +139,45 @@ mod module {
 
 #[manyhow(proc_macro_attribute)]
 pub use module::attr_use;
+
+#[manyhow]
+#[proc_macro]
+pub fn parse_quote(input: syn::LitStr) -> syn::LitStr {
+    input
+}
+
+#[manyhow(input_as_dummy)]
+#[proc_macro]
+pub fn parse_quote_dummy(input: syn::DeriveInput) -> syn::DeriveInput {
+    input
+}
+
+#[manyhow(input_as_dummy)]
+#[proc_macro]
+pub fn parse_quote_dummy_error(_: TokenStream) -> Result<syn::Ident> {
+    bail!("error message")
+}
+
+#[manyhow]
+#[proc_macro_attribute]
+pub fn parse_quote_attribute(_: syn::LitStr, item: syn::DeriveInput) -> syn::DeriveInput {
+    item
+}
+
+#[manyhow(item_as_dummy)]
+#[proc_macro_attribute]
+pub fn parse_quote_dummy_attribute(_: syn::LitStr, item: syn::DeriveInput) -> syn::DeriveInput {
+    item
+}
+
+#[manyhow(item_as_dummy)]
+#[proc_macro_attribute]
+pub fn parse_quote_dummy_error_attribute(_: TokenStream, _: TokenStream) -> Result<syn::Ident> {
+    bail!("error message")
+}
+
+#[manyhow]
+#[proc_macro_derive(ParseQuote)]
+pub fn parse_quote_derive(item: syn::ItemStruct) -> syn::ItemStruct {
+    item
+}

--- a/examples/macro/tests/test.rs
+++ b/examples/macro/tests/test.rs
@@ -12,6 +12,10 @@ fn attr() {
     #[attr_custom_dummy]
     struct ItemAsDummy; // does not conflict with above
     dummy();
+
+    #[parse_quote_attribute("string")]
+    struct Struct;
+    _ = Struct;
 }
 
 #[test]
@@ -29,6 +33,8 @@ fn function() {
         struct InputAsDummy;
     );
     dummy();
+
+    assert_eq!("hello", parse_quote!("hello"));
 }
 
 #[test]

--- a/examples/macro/tests/ui/parse.rs
+++ b/examples/macro/tests/ui/parse.rs
@@ -1,0 +1,35 @@
+use example_macro::*;
+
+#[parse_quote_attribute("hello")]
+fn test() {}
+
+#[parse_quote_attribute(1)]
+fn test() {}
+
+#[parse_quote_attribute]
+fn test() {}
+
+#[parse_quote_dummy_attribute]
+fn test_dummy() {}
+
+#[parse_quote_dummy_error_attribute]
+fn test_dummy2() {}
+
+parse_quote_dummy!(
+    fn test_dummy3() {}
+);
+parse_quote_dummy_error!(
+    fn test_dummy4() {}
+);
+
+#[derive(ParseQuote)]
+enum NoStruct{}
+
+fn main() {
+    // can be resolved through dummy
+    test_dummy();
+    test_dummy2();
+
+    test_dummy3();
+    test_dummy4();
+}

--- a/examples/macro/tests/ui/parse.stderr
+++ b/examples/macro/tests/ui/parse.stderr
@@ -1,0 +1,73 @@
+error: expected one of: `struct`, `enum`, `union`
+ --> tests/ui/parse.rs:4:1
+  |
+4 | fn test() {}
+  | ^^
+
+error: expected string literal
+ --> tests/ui/parse.rs:6:25
+  |
+6 | #[parse_quote_attribute(1)]
+  |                         ^
+
+error: unexpected end of input, expected string literal
+ --> tests/ui/parse.rs:9:1
+  |
+9 | #[parse_quote_attribute]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `parse_quote_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: while parsing attribute argument (`#[... (...)]`)
+ --> tests/ui/parse.rs:9:1
+  |
+9 | #[parse_quote_attribute]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `parse_quote_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected string literal
+  --> tests/ui/parse.rs:12:1
+   |
+12 | #[parse_quote_dummy_attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `parse_quote_dummy_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: while parsing attribute argument (`#[... (...)]`)
+  --> tests/ui/parse.rs:12:1
+   |
+12 | #[parse_quote_dummy_attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `parse_quote_dummy_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: error message
+  --> tests/ui/parse.rs:15:1
+   |
+15 | #[parse_quote_dummy_error_attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `parse_quote_dummy_error_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected one of: `struct`, `enum`, `union`
+  --> tests/ui/parse.rs:19:5
+   |
+19 |     fn test_dummy3() {}
+   |     ^^
+
+error: error message
+  --> tests/ui/parse.rs:21:1
+   |
+21 | / parse_quote_dummy_error!(
+22 | |     fn test_dummy4() {}
+23 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `parse_quote_dummy_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `struct`
+  --> tests/ui/parse.rs:26:1
+   |
+26 | enum NoStruct{}
+   | ^^^^

--- a/examples/no_macro/Cargo.toml
+++ b/examples/no_macro/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-manyhow = {path = "../..", default-features = false}
+manyhow = { path = "../..", default-features = false, features = ["syn"] }
 proc-macro2 = "1"
 quote = "1"
-syn = "2"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.80"

--- a/examples/no_macro/src/lib.rs
+++ b/examples/no_macro/src/lib.rs
@@ -1,4 +1,4 @@
-use manyhow::{attribute, derive, function, Emitter, ErrorMessage, Result, SilentError};
+use manyhow::{attribute, bail, derive, function, Emitter, ErrorMessage, Result, SilentError};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
@@ -123,4 +123,43 @@ pub fn derive_emit(item: TokenStream) -> TokenStream {
             quote! {fn output(){}}
         },
     )
+}
+
+#[proc_macro]
+pub fn parse_quote(input: TokenStream) -> TokenStream {
+    function!(input, |lit: syn::LitStr| lit)
+}
+
+#[proc_macro]
+pub fn parse_quote_dummy(input: TokenStream) -> TokenStream {
+    function!(#input_as_dummy input, |input: syn::DeriveInput| input)
+}
+
+#[proc_macro]
+pub fn parse_quote_dummy_error(input: TokenStream) -> TokenStream {
+    function!(#input_as_dummy input, |_: TokenStream| -> Result<syn::Ident> {
+        bail!("error message")
+    })
+}
+
+#[proc_macro_attribute]
+pub fn parse_quote_attribute(input: TokenStream, item: TokenStream) -> TokenStream {
+    attribute!(input, item, |_: syn::LitStr, item: syn::DeriveInput| item)
+}
+
+#[proc_macro_attribute]
+pub fn parse_quote_dummy_attribute(input: TokenStream, item: TokenStream) -> TokenStream {
+    attribute!(#item_as_dummy input, item, |_: TokenStream, item: syn::DeriveInput| item)
+}
+
+#[proc_macro_attribute]
+pub fn parse_quote_dummy_error_attribute(input: TokenStream, item: TokenStream) -> TokenStream {
+    attribute!(#item_as_dummy input, item, |_: TokenStream, _: TokenStream| -> Result<syn::Ident> {
+        bail!("error message")
+    })
+}
+
+#[proc_macro_derive(ParseQuote)]
+pub fn parse_quote_derive(item: TokenStream) -> TokenStream {
+    derive!(item, |item: syn::ItemStruct| item)
 }

--- a/examples/no_macro/src/lib.rs
+++ b/examples/no_macro/src/lib.rs
@@ -132,14 +132,20 @@ pub fn parse_quote(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn parse_quote_dummy(input: TokenStream) -> TokenStream {
-    function!(#input_as_dummy input, |input: syn::DeriveInput| input)
+    function!(
+        #[as_dummy]
+        input,
+        |input: syn::DeriveInput| input
+    )
 }
 
 #[proc_macro]
 pub fn parse_quote_dummy_error(input: TokenStream) -> TokenStream {
-    function!(#input_as_dummy input, |_: TokenStream| -> Result<syn::Ident> {
-        bail!("error message")
-    })
+    function!(
+        #[as_dummy]
+        input,
+        |_: TokenStream| -> Result<syn::Ident> { bail!("error message") }
+    )
 }
 
 #[proc_macro_attribute]
@@ -149,14 +155,22 @@ pub fn parse_quote_attribute(input: TokenStream, item: TokenStream) -> TokenStre
 
 #[proc_macro_attribute]
 pub fn parse_quote_dummy_attribute(input: TokenStream, item: TokenStream) -> TokenStream {
-    attribute!(#item_as_dummy input, item, |_: TokenStream, item: syn::DeriveInput| item)
+    attribute!(
+        input,
+        #[as_dummy]
+        item,
+        |_: TokenStream, item: syn::DeriveInput| item
+    )
 }
 
 #[proc_macro_attribute]
 pub fn parse_quote_dummy_error_attribute(input: TokenStream, item: TokenStream) -> TokenStream {
-    attribute!(#item_as_dummy input, item, |_: TokenStream, _: TokenStream| -> Result<syn::Ident> {
-        bail!("error message")
-    })
+    attribute!(
+        input,
+        #[as_dummy]
+        item,
+        |_: TokenStream, _: TokenStream| -> Result<syn::Ident> { bail!("error message") }
+    )
 }
 
 #[proc_macro_derive(ParseQuote)]

--- a/examples/no_macro/tests/test.rs
+++ b/examples/no_macro/tests/test.rs
@@ -12,6 +12,10 @@ fn attr() {
     #[attr_custom_dummy]
     struct ItemAsDummy; // does not conflict with above
     dummy();
+
+    #[parse_quote_attribute("string")]
+    struct Struct;
+    _ = Struct;
 }
 
 #[test]
@@ -29,6 +33,8 @@ fn function() {
         struct InputAsDummy;
     );
     dummy();
+
+    assert_eq!("hello", parse_quote!("hello"));
 }
 
 #[test]

--- a/examples/no_macro/tests/ui/parse.rs
+++ b/examples/no_macro/tests/ui/parse.rs
@@ -1,0 +1,32 @@
+use example_no_macro::*;
+
+#[parse_quote_attribute("hello")]
+fn test() {}
+
+#[parse_quote_attribute]
+fn test() {}
+
+#[parse_quote_dummy_attribute]
+fn test_dummy() {}
+
+#[parse_quote_dummy_error_attribute]
+fn test_dummy2() {}
+
+parse_quote_dummy!(
+    fn test_dummy3() {}
+);
+parse_quote_dummy_error!(
+    fn test_dummy4() {}
+);
+
+#[derive(ParseQuote)]
+enum NoStruct{}
+
+fn main() {
+    // can be resolved through dummy
+    test_dummy();
+    test_dummy2();
+
+    test_dummy3();
+    test_dummy4();
+}

--- a/examples/no_macro/tests/ui/parse.stderr
+++ b/examples/no_macro/tests/ui/parse.stderr
@@ -1,0 +1,57 @@
+error: expected one of: `struct`, `enum`, `union`
+ --> tests/ui/parse.rs:4:1
+  |
+4 | fn test() {}
+  | ^^
+
+error: unexpected end of input, expected string literal
+ --> tests/ui/parse.rs:6:1
+  |
+6 | #[parse_quote_attribute]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `parse_quote_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: while parsing attribute argument (`#[... (...)]`)
+ --> tests/ui/parse.rs:6:1
+  |
+6 | #[parse_quote_attribute]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `parse_quote_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected one of: `struct`, `enum`, `union`
+  --> tests/ui/parse.rs:10:1
+   |
+10 | fn test_dummy() {}
+   | ^^
+
+error: error message
+  --> tests/ui/parse.rs:12:1
+   |
+12 | #[parse_quote_dummy_error_attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `parse_quote_dummy_error_attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected one of: `struct`, `enum`, `union`
+  --> tests/ui/parse.rs:16:5
+   |
+16 |     fn test_dummy3() {}
+   |     ^^
+
+error: error message
+  --> tests/ui/parse.rs:18:1
+   |
+18 | / parse_quote_dummy_error!(
+19 | |     fn test_dummy4() {}
+20 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `parse_quote_dummy_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `struct`
+  --> tests/ui/parse.rs:23:1
+   |
+23 | enum NoStruct{}
+   | ^^^^

--- a/src/error.rs
+++ b/src/error.rs
@@ -236,13 +236,6 @@ impl Emitter {
         }
     }
 
-    #[cfg(feature = "syn")]
-    pub(crate) fn into_token_stream(self) -> TokenStream {
-        let mut tokens = TokenStream::new();
-        self.to_tokens(&mut tokens);
-        tokens
-    }
-
     /// Emitts an error
     pub fn emit(&mut self, error: impl ToTokensError + 'static) {
         self.0.push(Box::new(error));

--- a/src/error.rs
+++ b/src/error.rs
@@ -236,6 +236,13 @@ impl Emitter {
         }
     }
 
+    #[cfg(feature = "syn")]
+    pub(crate) fn into_token_stream(self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        self.to_tokens(&mut tokens);
+        tokens
+    }
+
     /// Emitts an error
     pub fn emit(&mut self, error: impl ToTokensError + 'static) {
         self.0.push(Box::new(error));

--- a/src/parse_to_tokens.rs
+++ b/src/parse_to_tokens.rs
@@ -90,6 +90,7 @@ macro_rules! transparent_handlers {
             $($dummy: Option<impl AnyTokenStream>,)?
             body: impl MacroHandler<($($Input,)*), Dummy, Output, Function, Error>,
         ) -> Result<(Output, TokenStream), TokenStream> {
+            // use $crate::ToTokensError as _;
             #[allow(unused)]
             let mut dummy = TokenStream::new();
             $(let mut dummy = $dummy.unwrap_or_default().into();)?
@@ -105,7 +106,7 @@ macro_rules! transparent_handlers {
             let mut emitter = Emitter::new();
             let output = body.call(($($input,)*), &mut tokens, &mut emitter);
             match output {
-                Ok(tokens) => Ok((tokens, emitter.into_token_stream())),
+                Ok(tokens) => Ok((tokens, emitter.into_result().err().map($crate::ToTokensError::into_token_stream).unwrap_or_default())),
                 Err(error) => {
                     let mut tokens = tokens.into();
                     error.to_tokens(&mut tokens);

--- a/src/parse_to_tokens.rs
+++ b/src/parse_to_tokens.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs, clippy::pedantic)]
 use std::marker::PhantomData;
 
 use proc_macro2::TokenStream;
@@ -14,16 +15,16 @@ pub struct WhatType<T>(PhantomData<T>);
 impl<T> WhatType<T> {
     /// Always panics
     pub fn identify(&self) -> Result<T, TokenStream> {
-        panic!("DON'T YOU DARE CALL ME")
+        unimplemented!("DON'T YOU DARE CALL ME")
     }
 
     pub fn from(_ty: &T) -> Self {
-        Self(Default::default())
+        Self(PhantomData)
     }
 
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Self(Default::default())
+        Self(PhantomData)
     }
 }
 

--- a/src/parse_to_tokens.rs
+++ b/src/parse_to_tokens.rs
@@ -1,0 +1,122 @@
+use std::marker::PhantomData;
+
+use proc_macro2::TokenStream;
+
+use crate::{AnyTokenStream, Emitter, MacroHandler, ToTokensError};
+pub trait ParseToTokens<T> {
+    fn manyhow_parse(&self, input: impl AnyTokenStream, attr: bool) -> Result<T, TokenStream>;
+    #[allow(clippy::wrong_self_convention)]
+    fn manyhow_into_token_stream(&self, input: T, tokens: TokenStream) -> TokenStream;
+}
+
+pub struct WhatType<T>(PhantomData<T>);
+
+impl<T> WhatType<T> {
+    /// Always panics
+    pub fn identify(&self) -> Result<T, TokenStream> {
+        panic!("DON'T YOU DARE CALL ME")
+    }
+
+    pub fn from(_ty: &T) -> Self {
+        Self(Default::default())
+    }
+
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> Clone for WhatType<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for WhatType<T> {}
+
+impl<T: Into<TokenStream> + From<TokenStream>> ParseToTokens<T> for WhatType<T> {
+    fn manyhow_parse(&self, input: impl AnyTokenStream, _attr: bool) -> Result<T, TokenStream> {
+        Ok(input.into().into())
+    }
+
+    fn manyhow_into_token_stream(&self, input: T, mut tokens: TokenStream) -> TokenStream {
+        tokens.extend(input.into());
+        tokens
+    }
+}
+
+#[cfg(feature = "syn2")]
+impl<T: syn2::parse::Parse + quote::ToTokens> ParseToTokens<T> for &WhatType<T> {
+    fn manyhow_parse(&self, input: impl AnyTokenStream, attr: bool) -> Result<T, TokenStream> {
+        let input = input.into();
+        let empty = input.is_empty();
+        syn2::parse2(input).map_err(|e| {
+            let mut e = e.into_compile_error();
+            if attr && empty {
+                error_message!("while parsing attribute argument (`#[... (...)]`)")
+                    .to_tokens(&mut e)
+            }
+            e
+        })
+    }
+
+    fn manyhow_into_token_stream(&self, input: T, mut tokens: TokenStream) -> TokenStream {
+        input.to_tokens(&mut tokens);
+        tokens
+    }
+}
+
+#[cfg(feature = "syn2")]
+#[test]
+#[allow(unused)]
+fn test_inference() {
+    if false {
+        let wt = &WhatType::new();
+        let ts: proc_macro::TokenStream = wt.manyhow_parse(quote::quote!(test), false).unwrap();
+        let wt = &WhatType::new();
+        if false {
+            let wt: Result<syn2::Ident, _> = wt.identify();
+        }
+        let ts: syn2::Ident = wt.manyhow_parse(quote::quote!(test), false).unwrap();
+    }
+}
+
+macro_rules! transparent_handlers {
+    ($name:ident; $($input:ident: $Input:ident $($context:expr)?),*; $($dummy:ident)?) => {
+        /// Internal implementation for macro.
+        pub fn $name<$($Input,)* Dummy: AnyTokenStream, Output, Error: ToTokensError, Function,>(
+            $($input: Result<$Input, TokenStream>,)*
+            $($dummy: Option<impl AnyTokenStream>,)?
+            body: impl MacroHandler<($($Input,)*), Dummy, Output, Function, Error>,
+        ) -> Result<(Output, TokenStream), TokenStream> {
+            #[allow(unused)]
+            let mut dummy = TokenStream::new();
+            $(let mut dummy = $dummy.unwrap_or_default().into();)?
+            $(let $input = match $input {
+                Ok($input) => $input,
+                Err(tokens) => {
+                    dummy.extend(tokens);
+                    $($crate::error_message!($context).to_tokens(&mut dummy);)?
+                    return Err(dummy);
+                }
+            };)*
+            let mut tokens = dummy.into();
+            let mut emitter = Emitter::new();
+            let output = body.call(($($input,)*), &mut tokens, &mut emitter);
+            match output {
+                Ok(tokens) => Ok((tokens, emitter.into_token_stream())),
+                Err(error) => {
+                    let mut tokens = tokens.into();
+                    error.to_tokens(&mut tokens);
+                    emitter.to_tokens(&mut tokens);
+                    Err(tokens)
+                }
+            }
+        }
+    };
+}
+
+transparent_handlers! { function_transparent; input: Input; dummy }
+transparent_handlers! { derive_transparent; item: Item; }
+transparent_handlers! { attribute_transparent; input: Input, item: Item; dummy }


### PR DESCRIPTION
- [x] add documentation
- [x] remove syn requirement to use the macro

closes #10 