### PR TITLE
Update proc-macro-utils dev-dependency to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ syn = ["syn2"]
 darling = ["darling_core"]
 
 [dev-dependencies]
-proc-macro-utils = "0.8.0"
+proc-macro-utils = "0.10.0"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 syn2 = {package = "syn", version = "2", features = ["full"]}
 


### PR DESCRIPTION
The `manyhow-macros` already had a dependency on 0.10.0:

https://github.com/ModProg/manyhow/blob/fa3aeeb4c6555b63ff39e4c54afc6ef66e31dbbc/macros/Cargo.toml#L18

https://github.com/ModProg/proc-macro-utils/blob/v0.10.0/CHANGELOG.md#0100---2024-05-21