### PR TITLE
feat: bump daring to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1"
 syn1 = { package = "syn", version = "1", default-features = false, optional = true, features = ["printing"] }
 syn2 = { package = "syn", version = "2", default-features = false, optional = true, features = ["printing", "parsing"] }
 syn3 = { package = "syn", version = "3", default-features = false, optional = true, features = ["printing", "parsing"] }
-darling_core = { version = "0.23.0", optional = true }
+darling_core = { version = "0.24.0", optional = true }
 
 [features]
 default = ["syn", "macros"]


### PR DESCRIPTION
daring also follow the syn3, so we also need to follow it, and maybe we also need to publish a new version for it